### PR TITLE
feat: Fix freeze report download

### DIFF
--- a/src/pages/Auth/context/AuthContext.tsx
+++ b/src/pages/Auth/context/AuthContext.tsx
@@ -96,6 +96,9 @@ export function AuthProvider({ children }: IAuthProviderProps) {
 
   const logout = () => {
     storage.remove('TOKEN');
+    document.cookie =
+      'ACCESS_TOKEN' +
+      '=; Path=/api/reports/download; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
     setUser(null);
   };
 

--- a/src/services/auth/mutation/useLoginAccount.tsx
+++ b/src/services/auth/mutation/useLoginAccount.tsx
@@ -11,7 +11,8 @@ export type UserDTO = {
 };
 
 const loginAccount = async (user: UserDTO) => {
-  return (await axiosClient.post(`auth/login`, user)).data as LoginResponse;
+  return (await axiosClient.post(`auth/login`, user, { withCredentials: true }))
+    .data as LoginResponse;
 };
 
 export const useLoginAccount = (

--- a/src/services/report/queries/useDownloadHistoricalReports.tsx
+++ b/src/services/report/queries/useDownloadHistoricalReports.tsx
@@ -44,25 +44,8 @@ export const downloadHistoricalReports = async (
   if (params.order) {
     formattedParams.append('order', params.order);
   }
-
-  const token = storage.get('TOKEN');
-
-  const headers = new Headers({
-    Authorization: `Bearer ${token}`,
-  });
-
-  fetch(`${baseURL}reports/download?` + formattedParams.toString(), {
-    headers,
-  })
-    .then((response) => response.blob())
-    .then((blob) => {
-      const desiredFileName = 'reports.zip';
-
-      const link = document.createElement('a');
-      link.href = URL.createObjectURL(blob);
-      link.download = desiredFileName;
-      link.click();
-
-      link.onload = () => URL.revokeObjectURL(link.href);
-    });
+  const link = document.createElement('a');
+  link.href = `${baseURL}/reports/download?` + formattedParams.toString();
+  document.body.appendChild(link);
+  link.click();
 };

--- a/src/services/report/queries/useDownloadHistoricalReports.tsx
+++ b/src/services/report/queries/useDownloadHistoricalReports.tsx
@@ -1,4 +1,3 @@
-import { storage } from '~/utils';
 import { toISOStringWithoutTimeZone } from '~/utils/date';
 const baseURL = import.meta.env.VITE_API_URL as string;
 


### PR DESCRIPTION
A cookie is set only for /download path. This way, we will reduce the impact of messing tokens.